### PR TITLE
Add mgos_bt_gap_parse_service_data()

### DIFF
--- a/include/mgos_bt_gap.h
+++ b/include/mgos_bt_gap.h
@@ -47,15 +47,22 @@ enum mgos_bt_gap_eir_type {
   MGOS_BT_GAP_EIR_SHORT_NAME = 0x8,
   MGOS_BT_GAP_EIR_FULL_NAME = 0x9,
   MGOS_BT_GAP_EIR_DEVICE_ID = 0x10,
+  MGOS_BT_GAP_EIR_SERVICE_DATA_16 = 0x16,
+  MGOS_BT_GAP_EIR_SERVICE_DATA_32 = 0x20,
+  MGOS_BT_GAP_EIR_SERVICE_DATA_128 = 0x21,
   MGOS_BT_GAP_EIR_URL = 0x24,
   MGOS_BT_GAP_EIR_MANUFACTURER_SPECIFIC_DATA = 0xff,
 };
 
-struct mg_str mgos_bt_gap_parse_adv_data(const struct mg_str adv_data,
+struct mg_str mgos_bt_gap_parse_adv_data(struct mg_str adv_data,
                                          enum mgos_bt_gap_eir_type);
 
 /* Either LONG or, if not provided, SHORT_NAME. */
-struct mg_str mgos_bt_gap_parse_name(const struct mg_str adv_data);
+struct mg_str mgos_bt_gap_parse_name(struct mg_str adv_data);
+
+/* Returns service data for a specific service (if present). */
+struct mg_str mgos_bt_gap_parse_service_data(struct mg_str adv_data,
+                                             const struct mgos_bt_uuid *svc_uuid);
 
 struct mgos_bt_gap_scan_result {
   struct mgos_bt_addr addr; /* MAC address. Can change randomly. */

--- a/src/mgos_bt_gap.c
+++ b/src/mgos_bt_gap.c
@@ -17,11 +17,13 @@
 
 #include "mgos_bt_gap.h"
 
+#include <string.h>
+
 #ifdef MGOS_HAVE_MJS
 #include "mjs.h"
 #endif
 
-struct mg_str mgos_bt_gap_parse_adv_data(const struct mg_str adv_data,
+struct mg_str mgos_bt_gap_parse_adv_data(struct mg_str adv_data,
                                          enum mgos_bt_gap_eir_type t) {
   const uint8_t *dp = (const uint8_t *) adv_data.p;
   struct mg_str res = MG_NULL_STR;
@@ -38,11 +40,41 @@ struct mg_str mgos_bt_gap_parse_adv_data(const struct mg_str adv_data,
   return res;
 }
 
-struct mg_str mgos_bt_gap_parse_name(const struct mg_str adv_data) {
+struct mg_str mgos_bt_gap_parse_name(struct mg_str adv_data) {
   struct mg_str s =
       mgos_bt_gap_parse_adv_data(adv_data, MGOS_BT_GAP_EIR_FULL_NAME);
   if (s.len == 0) {
     s = mgos_bt_gap_parse_adv_data(adv_data, MGOS_BT_GAP_EIR_SHORT_NAME);
   }
   return s;
+}
+
+struct mg_str mgos_bt_gap_parse_service_data(struct mg_str adv_data,
+                                             const struct mgos_bt_uuid *svc_uuid) {
+  enum mgos_bt_gap_eir_type et;
+  switch (svc_uuid->len) {
+    case sizeof(svc_uuid->uuid.uuid16):
+      et = MGOS_BT_GAP_EIR_SERVICE_DATA_16;
+      break;
+    case sizeof(svc_uuid->uuid.uuid32):
+      et = MGOS_BT_GAP_EIR_SERVICE_DATA_32;
+      break;
+    case sizeof(svc_uuid->uuid.uuid128):
+      et = MGOS_BT_GAP_EIR_SERVICE_DATA_128;
+      break;
+    default:
+      goto out;
+  }
+  while (adv_data.len > 0) {
+    struct mg_str svc_data = mgos_bt_gap_parse_adv_data(adv_data, et);
+    if (svc_data.len < svc_uuid->len) break;
+    if (memcmp(svc_data.p, &svc_uuid->uuid, svc_uuid->len) == 0) {
+      return mg_mk_str_n(svc_data.p + svc_uuid->len, svc_data.len - svc_uuid->len);
+    }
+    svc_data.p += svc_data.len;
+    adv_data.len = adv_data.len - (svc_data.p - adv_data.p);
+    adv_data.p = svc_data.p;
+  }
+out:
+  return mg_mk_str_n(NULL, 0);
 }


### PR DESCRIPTION
To extract specific service data from adv data.

CL: bt-common: Add mgos_bt_gap_parse_service_data - extract specific service data from adv data