### PR TITLE
Allow overriding ESP32 BLE scan interval & window

### DIFF
--- a/include/mgos_bt_gap.h
+++ b/include/mgos_bt_gap.h
@@ -39,6 +39,8 @@ enum mgos_bt_gap_event {
 struct mgos_bt_gap_scan_opts {
   int duration_ms;
   bool active;
+  int interval_ms;
+  int window_ms;
 };
 
 // https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile

--- a/src/esp32/esp32_bt_gap.c
+++ b/src/esp32/esp32_bt_gap.c
@@ -150,8 +150,9 @@ bool mgos_bt_gap_scan(const struct mgos_bt_gap_scan_opts *opts) {
   struct mgos_bt_scan_ctx *ctx = calloc(1, sizeof(*ctx));
   if (ctx == NULL) return false;
   struct ble_gap_disc_params params = {
-      .itvl = MGOS_BT_GAP_DEFAULT_SCAN_INTERVAL_MS / 0.625,
-      .window = MGOS_BT_GAP_DEFAULT_SCAN_WINDOW_MS / 0.625,
+      .itvl =
+          (opts->interval_ms ?: MGOS_BT_GAP_DEFAULT_SCAN_INTERVAL_MS) / 0.625,
+      .window = (opts->window_ms ?: MGOS_BT_GAP_DEFAULT_SCAN_WINDOW_MS) / 0.625,
       .filter_policy = BLE_HCI_SCAN_FILT_NO_WL,
       .limited = false,
       .passive = !opts->active,


### PR DESCRIPTION
80% time was spent in BLE scanning by default, which could severely limit WiFi
throughput and stability.  Allow the user tweak these settings to their needs.