### PR TITLE
Fix advertisement data parsing

### DIFF
--- a/src/mgos_bt_gap.c
+++ b/src/mgos_bt_gap.c
@@ -29,6 +29,7 @@ struct mg_str mgos_bt_gap_parse_adv_data(struct mg_str adv_data,
   struct mg_str res = MG_NULL_STR;
   for (size_t i = 0; i < adv_data.len;) {
     size_t len = dp[i];
+    if (len == 0) break;
     if (i + len + 1 > adv_data.len) break;
     if (dp[i + 1] == t) {
       res.p = (const char *) dp + i + 2;

--- a/src/mgos_bt_gap.c
+++ b/src/mgos_bt_gap.c
@@ -69,13 +69,15 @@ bool mgos_bt_gap_adv_data_has_service(struct mg_str adv_data,
     default:
       return false;
   }
-  struct mg_str d = adv_data;
-  while ((d = mgos_bt_gap_parse_adv_data(d, t1)).len == svc_uuid->len) {
-    if (memcmp(d.p, svc_uuid->uuid.uuid128, svc_uuid->len) == 0) return true;
+  struct mg_str d = mgos_bt_gap_parse_adv_data(adv_data, t1);
+  for (int next = 0; next < d.len; next += svc_uuid->len) {
+    if (next + svc_uuid->len > d.len) break;
+    if (memcmp(d.p + next, svc_uuid->uuid.uuid128, svc_uuid->len) == 0) return true;
   }
-  d = adv_data;
-  while ((d = mgos_bt_gap_parse_adv_data(d, t2)).len == svc_uuid->len) {
-    if (memcmp(d.p, svc_uuid->uuid.uuid128, svc_uuid->len) == 0) return true;
+  d = mgos_bt_gap_parse_adv_data(adv_data, t2);
+  for (int next = 0; next < d.len; next += svc_uuid->len) {
+    if (next + svc_uuid->len > d.len) break;
+    if (memcmp(d.p + next, svc_uuid->uuid.uuid128, svc_uuid->len) == 0) return true;
   }
   return false;
 }

--- a/src/mgos_bt_gap.c
+++ b/src/mgos_bt_gap.c
@@ -69,15 +69,14 @@ bool mgos_bt_gap_adv_data_has_service(struct mg_str adv_data,
     default:
       return false;
   }
-  struct mg_str d = mgos_bt_gap_parse_adv_data(adv_data, t1);
-  for (int next = 0; next < d.len; next += svc_uuid->len) {
-    if (next + svc_uuid->len > d.len) break;
-    if (memcmp(d.p + next, svc_uuid->uuid.uuid128, svc_uuid->len) == 0) return true;
+  const size_t slen = svc_uuid->len;
+  const struct mg_str d1 = mgos_bt_gap_parse_adv_data(adv_data, t1);
+  for (size_t next = 0; next + slen <= d1.len; next += slen) {
+    if (memcmp(d1.p + next, svc_uuid->uuid.uuid128, slen) == 0) return true;
   }
-  d = mgos_bt_gap_parse_adv_data(adv_data, t2);
-  for (int next = 0; next < d.len; next += svc_uuid->len) {
-    if (next + svc_uuid->len > d.len) break;
-    if (memcmp(d.p + next, svc_uuid->uuid.uuid128, svc_uuid->len) == 0) return true;
+  const struct mg_str d2 = mgos_bt_gap_parse_adv_data(adv_data, t2);
+  for (size_t next = 0; next + slen <= d2.len; next += slen) {
+    if (memcmp(d2.p + next, svc_uuid->uuid.uuid128, slen) == 0) return true;
   }
   return false;
 }


### PR DESCRIPTION
We observed that some bluetooth devices send advertisement data padded with zeroes to 31 bytes. This causes the parsing function to treat it as zero length data type which in some cases produces invalid result and causes a crash in our code. So I added a check  to abort the parsing on such condition. Also it seems that the function mgos_bt_gap_adv_data_has_service, doesn't parse correctly the data if there is more than one service uuid in the same data type entry. According to the standard there can be only one entry for the class of service uuid and if there are more than one uuids they are listed one next to the other in the same entry. The existing code seems to work as if they are in separate entries, so I have proposed a change which parses more than one uuid in the same entry.